### PR TITLE
Fixes #1: use correct syntax for ts() in extensions.

### DIFF
--- a/CRM/Sumfields/Form/SumFields.php
+++ b/CRM/Sumfields/Form/SumFields.php
@@ -14,19 +14,17 @@ class CRM_Sumfields_Form_SumFields extends CRM_Core_Form {
     if(count($field_options) == 0) {
       // This means neither CiviEvent or CiviContribute are enabled.
       $session = CRM_Core_Session::singleton();
-      $session->setStatus(ts("Summary Fields is not particularly useful if
-        CiviContribute and CiviEvent are both disabled. Try enabling at least
-        one."));
+      $session->setStatus(ts("Summary Fields is not particularly useful if CiviContribute and CiviEvent are both disabled. Try enabling at least one.", array('domain' => 'net.ourpowerbase.sumfields')));
       return;
     }
     // Evaluate the status of form changes and report to the user
     $apply_settings_status = sumfields_get_setting('generate_schema_and_data', FALSE);
 
     if(empty($apply_settings_status)) {
-      $display_status = ts('The settings have never been saved (newly enabled)');
+      $display_status = ts('The settings have never been saved (newly enabled)', array('domain' => 'net.ourpowerbase.sumfields'));
     }
     elseif(!preg_match('/^(scheduled|running|success|failed):([0-9 :\-]+)$/', $apply_settings_status, $matches)) {
-      $display_status = ts("Unable to determine status (%1).", array(1 => $apply_settings_status));
+      $display_status = ts("Unable to determine status (%1).", array(1 => $apply_settings_status, 'domain' => 'net.ourpowerbase.sumfields'));
     }
     else {
       $display_status = NULL;
@@ -34,20 +32,16 @@ class CRM_Sumfields_Form_SumFields extends CRM_Core_Form {
       $date = $matches[2];
       switch($status) {
       case 'scheduled':
-        $display_status = ts("Setting changes were saved on %1, but not yet applied; they should be applied shortly.",
-          array(1 => $date));
+        $display_status = ts("Setting changes were saved on %1, but not yet applied; they should be applied shortly.", array(1 => $date, 'domain' => 'net.ourpowerbase.sumfields'));
         break;
       case 'running':
-        $display_status = ts("Setting changes are in the process of being applied; the process started on %1.",
-          array(1 => $date));
+        $display_status = ts("Setting changes are in the process of being applied; the process started on %1.", array(1 => $date, 'domain' => 'net.ourpowerbase.sumfields'));
         break;
       case 'success':
-        $display_status = ts("Setting changes were successfully applied on %1.",
-          array(1 => $date));
+        $display_status = ts("Setting changes were successfully applied on %1.", array(1 => $date, 'domain' => 'net.ourpowerbase.sumfields'));
         break;
       case 'failed':
-        $display_status = ts("Setting changes failed to apply; the failed attempt happend on %1.",
-          array(1 => $date));
+        $display_status = ts("Setting changes failed to apply; the failed attempt happend on %1.", array(1 => $date, 'domain' => 'net.ourpowerbase.sumfields'));
         break;
       }
     }
@@ -79,7 +73,7 @@ class CRM_Sumfields_Form_SumFields extends CRM_Core_Form {
     if(array_key_exists('fundraising', $field_options)) {
       $this->Assign('sumfields_active_fundraising', TRUE);
       $name = 'active_fundraising_fields';
-      $label = ts('Fundraising Fields');
+      $label = ts('Fundraising Fields', array('domain' => 'net.ourpowerbase.sumfields'));
       $this->addCheckBox(
         $name, $label, array_flip($field_options['fundraising'])
       );
@@ -90,7 +84,7 @@ class CRM_Sumfields_Form_SumFields extends CRM_Core_Form {
 
       $this->Assign('sumfields_active_membership', TRUE);
       $name = 'active_membership_fields';
-      $label = ts('Membership Fields');
+      $label = ts('Membership Fields', array('domain' => 'net.ourpowerbase.sumfields'));
       $this->addCheckBox(
         $name, $label, array_flip($field_options['membership'])
       );
@@ -99,7 +93,7 @@ class CRM_Sumfields_Form_SumFields extends CRM_Core_Form {
     if(array_key_exists('event_standard', $field_options)) {
       $this->Assign('sumfields_active_event_standard', TRUE);
       $name = 'active_event_standard_fields';
-      $label = ts('Standard Event Fields');
+      $label = ts('Standard Event Fields', array('domain' => 'net.ourpowerbase.sumfields'));
       $this->addCheckBox(
         $name, $label, array_flip($field_options['event_standard'])
       );
@@ -107,7 +101,7 @@ class CRM_Sumfields_Form_SumFields extends CRM_Core_Form {
     if(array_key_exists('event_turnout', $field_options)) {
       $this->Assign('sumfields_active_event_turnout', TRUE);
       $name = 'active_event_turnout_fields';
-      $label = ts('Turnout Event Fields');
+      $label = ts('Turnout Event Fields', array('domain' => 'net.ourpowerbase.sumfields'));
       $this->addCheckBox(
         $name, $label, array_flip($field_options['event_turnout'])
       );
@@ -116,53 +110,53 @@ class CRM_Sumfields_Form_SumFields extends CRM_Core_Form {
     if(sumfields_component_enabled('CiviMember')) {
       $this->assign('sumfields_member', TRUE);
       $name = 'membership_financial_type_ids';
-      $label = ts('Membership Financial Types');
+      $label = ts('Membership Financial Types', array('domain' => 'net.ourpowerbase.sumfields'));
       $this->addCheckBox(
         $name, $label, array_flip(sumfields_get_all_financial_types())
       );
-      $this->addRule($name, ts('%1 is a required field.', array(1 => $label)), 'required');
+      $this->addRule($name, ts('%1 is a required field.', array(1 => $label, 'domain' => 'net.ourpowerbase.sumfields')), 'required');
     }
     if(sumfields_component_enabled('CiviContribute')) {
       $this->assign('sumfields_contribute', TRUE);
       $name = 'financial_type_ids';
-      $label = ts('Financial Types');
+      $label = ts('Financial Types', array('domain' => 'net.ourpowerbase.sumfields'));
       $this->addCheckBox(
         $name, $label, array_flip(sumfields_get_all_financial_types())
       );
-      $this->addRule($name, ts('%1 is a required field.', array(1 => $label)), 'required');
+      $this->addRule($name, ts('%1 is a required field.', array(1 => $label, 'domain' => 'net.ourpowerbase.sumfields')), 'required');
     }
     if(sumfields_component_enabled('CiviEvent')) {
       $this->assign('sumfields_event', TRUE);
       $name = 'event_type_ids';
-      $label = ts('Event Types');
+      $label = ts('Event Types', array('domain' => 'net.ourpowerbase.sumfields'));
       $this->addCheckBox(
         $name, $label, array_flip(sumfields_get_all_event_types())
       );
-      $this->addRule($name, ts('%1 is a required field.', array(1 => $label)), 'required');
+      $this->addRule($name, ts('%1 is a required field.', array(1 => $label, 'domain' => 'net.ourpowerbase.sumfields')), 'required');
 
-      $label = ts('Participant Status (attended)');
+      $label = ts('Participant Status (attended)', array('domain' => 'net.ourpowerbase.sumfields'));
       $name = 'participant_status_ids';
       $this->addCheckBox(
         $name, 
         $label,
         array_flip(sumfields_get_all_participant_status_types())
       );
-      $this->addRule($name, ts('%1 is a required field.', array(1 => $label)), 'required');
-      $label = ts('Participant Status (did not attend)');
+      $this->addRule($name, ts('%1 is a required field.', array(1 => $label, 'domain' => 'net.ourpowerbase.sumfields')), 'required');
+      $label = ts('Participant Status (did not attend)', array('domain' => 'net.ourpowerbase.sumfields'));
       $name = 'participant_noshow_status_ids';
       $this->addCheckBox(
         $name,
         $label,
         array_flip(sumfields_get_all_participant_status_types())
       );
-      $this->addRule($name, ts('%1 is a required field.', array(1 => $label)), 'required');
+      $this->addRule($name, ts('%1 is a required field.', array(1 => $label, 'domain' => 'net.ourpowerbase.sumfields')), 'required');
     }
 
     $name = 'when_to_apply_change';
-    $label = ts('When should these changes be applied?');
+    $label = ts('When should these changes be applied?', array('domain' => 'net.ourpowerbase.sumfields'));
     $options = array(
-      'via_cron' => ts("On the next scheduled job (cron)"),
-      'on_submit' => ts("When I submit this form")
+      'via_cron' => ts("On the next scheduled job (cron)", array('domain' => 'net.ourpowerbase.sumfields')),
+      'on_submit' => ts("When I submit this form", array('domain' => 'net.ourpowerbase.sumfields'))
     );
     $this->addRadio(
       $name, $label, $options
@@ -270,14 +264,14 @@ class CRM_Sumfields_Form_SumFields extends CRM_Core_Form {
     if($values['when_to_apply_change'] == 'on_submit') {
       $returnValues = array();
       if(!sumfields_gen_data($returnValues)) {
-        $msg = ts("There was an error applying your changes.");
+        $msg = ts("There was an error applying your changes.", array('domain' => 'net.ourpowerbase.sumfields'));
       }
       else {
-        $msg = ts("Changes were applied successfully.");
+        $msg = ts("Changes were applied successfully.", array('domain' => 'net.ourpowerbase.sumfields'));
       }
     }
     else {
-      $session->setStatus(ts("Your summary fields will begin being generated on the next scheduled job. It may take up to an hour to complete."));
+      $session->setStatus(ts("Your summary fields will begin being generated on the next scheduled job. It may take up to an hour to complete.", array('domain' => 'net.ourpowerbase.sumfields')));
     }
     $session->replaceUserContext(CRM_Utils_System::url('civicrm/admin/setting/sumfields'));
   }

--- a/custom.php
+++ b/custom.php
@@ -35,7 +35,7 @@ $custom = array(
 	'groups' => array(
 		'summary_fields' => array(
 			'name' => 'Summary_Fields',
-			'title' => ts('Summary Fields'),
+			'title' => ts('Summary Fields', array('domain' => 'net.ourpowerbase.sumfields')),
 			'extends' => 'Contact',
 			'style' => 'Tab',
 			'collapse_display' => '0',
@@ -50,7 +50,7 @@ $custom = array(
   ),
 	'fields' => array(
 		'contribution_total_lifetime' => array(
-			'label' => ts('Total Lifetime Contributions'),
+			'label' => ts('Total Lifetime Contributions', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Money',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -67,7 +67,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
 		'contribution_total_this_year' => array(
-			'label' => ts('Total Contributions this Year'),
+			'label' => ts('Total Contributions this Year', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Money',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -85,7 +85,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
     'contribution_total_deductible_this_year' => array(
-			'label' => ts('Total Deductible Contributions this Year'),
+			'label' => ts('Total Deductible Contributions this Year', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Money',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -105,7 +105,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
 		'contribution_total_last_year' => array(
-			'label' => ts('Total Contributions last Year'),
+			'label' => ts('Total Contributions last Year', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Money',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -123,7 +123,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
     'contribution_total_deductible_last_year' => array(
-			'label' => ts('Total Deductible Contributions last Year'),
+			'label' => ts('Total Deductible Contributions last Year', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Money',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -143,7 +143,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
     'contribution_total_year_before_last' => array(
-			'label' => ts('Total Contributions Year Before Last'),
+			'label' => ts('Total Contributions Year Before Last', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Money',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -161,7 +161,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
     'contribution_total_deductible_year_before_last_year' => array(
-			'label' => ts('Total Deductible Contributions Year Before Last'),
+			'label' => ts('Total Deductible Contributions Year Before Last', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Money',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -181,7 +181,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
 		'contribution_amount_last' => array(
-			'label' => ts('Amount of last contribution'),
+			'label' => ts('Amount of last contribution', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Money',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -199,7 +199,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
 		'contribution_date_last' => array(
-			'label' => ts('Date of Last Contribution'),
+			'label' => ts('Date of Last Contribution', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Date',
 			'html_type' => 'Select Date',
 			'is_required' => '0',
@@ -216,7 +216,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
 		'contribution_date_first' => array(
-			'label' => ts('Date of First Contribution'),
+			'label' => ts('Date of First Contribution', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Date',
 			'html_type' => 'Select Date',
 			'is_required' => '0',
@@ -234,7 +234,7 @@ $custom = array(
 
 		),
 		'contribution_largest' => array(
-			'label' => ts('Largest Contribution'),
+			'label' => ts('Largest Contribution', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Money',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -251,7 +251,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
 		'contribution_total_number' => array(
-			'label' => ts('Count of Contributions'),
+			'label' => ts('Count of Contributions', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Int',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -268,7 +268,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
     'contribution_average_annual_amount' => array(
-			'label' => ts('Average Annual (Calendar Year) Contribution'),
+			'label' => ts('Average Annual (Calendar Year) Contribution', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Money',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -287,7 +287,7 @@ $custom = array(
       'display' => 'fundraising',
 		),
     'contribution_date_last_membership_payment' => array(
-			'label' => ts('Date of Last Membership Payment'),
+			'label' => ts('Date of Last Membership Payment', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Date',
 			'html_type' => 'Select Date',
 			'is_required' => '0',
@@ -305,7 +305,7 @@ $custom = array(
       'display' => 'membership',
 		),
     'contribution_amount_last_membership_payment' => array(
-			'label' => ts('Amount of Last Membership Payment'),
+			'label' => ts('Amount of Last Membership Payment', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Money',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -323,7 +323,7 @@ $custom = array(
       'display' => 'membership',
 		),
     'event_last_attended_name' => array(
-			'label' => ts('Name of the last attended event'),
+			'label' => ts('Name of the last attended event', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'String',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -341,7 +341,7 @@ $custom = array(
       'display' => 'event_standard',
 		),
     'event_last_attended_date' => array(
-			'label' => ts('Date of the last attended event'),
+			'label' => ts('Date of the last attended event', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Date',
 			'html_type' => 'Select Date',
 			'is_required' => '0',
@@ -359,7 +359,7 @@ $custom = array(
 		),
     
     'event_total' => array(
-			'label' => ts('Total Number of events'),
+			'label' => ts('Total Number of events', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Int',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -374,7 +374,7 @@ $custom = array(
       'display' => 'event_standard',
 		),
     'event_attended' => array(
-      'label' => ts('Number of events attended'),
+      'label' => ts('Number of events attended', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Int',
       'html_type' => 'Text',
       'is_required' => '0',
@@ -389,7 +389,7 @@ $custom = array(
       'display' => 'event_standard',
     ),
     'event_attended_percent_total' => array(
-      'label' => ts('Events attended as percent of total'),
+      'label' => ts('Events attended as percent of total', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Int',
       'html_type' => 'Text',
       'is_required' => '0',
@@ -407,7 +407,7 @@ $custom = array(
       'display' => 'event_standard',
     ),
     'event_noshow' => array(
-      'label' => ts('Number of no-show events'),
+      'label' => ts('Number of no-show events', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Int',
       'html_type' => 'Text',
       'is_required' => '0',
@@ -422,7 +422,7 @@ $custom = array(
       'display' => 'event_standard',
     ),
     'event_noshow_percent_total' => array(
-      'label' => ts('No-shows as percent of total events'),
+      'label' => ts('No-shows as percent of total events', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Int',
       'html_type' => 'Text',
       'is_required' => '0',
@@ -438,7 +438,7 @@ $custom = array(
       'display' => 'event_standard',
     ),
     'event_turnout_attempts' => array(
-			'label' => ts('Number of turnout attempts'),
+			'label' => ts('Number of turnout attempts', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Int',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -453,7 +453,7 @@ $custom = array(
       'display' => 'event_turnout',
 		),
     'event_turnout_attended' => array(
-			'label' => ts('Number attended from turnout attempts'),
+			'label' => ts('Number attended from turnout attempts', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Int',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -468,7 +468,7 @@ $custom = array(
       'display' => 'event_turnout',
 		),
     'event_turnout_noshow' => array(
-			'label' => ts('Number noshow from turnout attempts'),
+			'label' => ts('Number noshow from turnout attempts', array('domain' => 'net.ourpowerbase.sumfields')),
 			'data_type' => 'Int',
 			'html_type' => 'Text',
 			'is_required' => '0',
@@ -483,7 +483,7 @@ $custom = array(
       'display' => 'event_turnout',
 		),
     'event_attended_percent_turnout' => array(
-      'label' => ts('Attended as percent of turn out attempts'),
+      'label' => ts('Attended as percent of turn out attempts', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Int',
       'html_type' => 'Text',
       'is_required' => '0',
@@ -499,7 +499,7 @@ $custom = array(
       'display' => 'event_turnout',
     ),
     'event_noshow_percent_turnout' => array(
-      'label' => ts('No-shows as percent of turn out attempts'),
+      'label' => ts('No-shows as percent of turn out attempts', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Int',
       'html_type' => 'Text',
       'is_required' => '0',

--- a/sumfields.php
+++ b/sumfields.php
@@ -26,7 +26,7 @@ function sumfields_civicrm_xmlMenu(&$files) {
 function sumfields_civicrm_navigationMenu(&$params) {
   $path = "Administer/Customize Data and Screens";
   $item = array(
-    'label' => ts('Summary Fields'),
+    'label' => ts('Summary Fields', array('net.ourpowerbase.sumfields')),
     'name' => 'Summary Fields',
     'url' => 'civicrm/admin/setting/sumfields',
     'permission' => 'administer CiviCRM',
@@ -59,10 +59,10 @@ function sumfields_civicrm_enable() {
   sumfields_initialize_user_settings();
   $session = CRM_Core_Session::singleton();
   if(!sumfields_create_custom_fields_and_table()) {
-    $msg = ts("Failed to create custom fields and table. Maybe they already exist?");
+    $msg = ts("Failed to create custom fields and table. Maybe they already exist?", array('domain' => 'net.ourpowerbase.sumfields'));
     $session->setStatus($msg);
   }
-  $msg = ts("The extension is enabled. Please go to Adminster -> Customize Data and Screens -> Summary Fields to configure it.");
+  $msg = ts("The extension is enabled. Please go to Adminster -> Customize Data and Screens -> Summary Fields to configure it.", array('domain' => 'net.ourpowerbase.sumfields'));
   $session->setStatus($msg);
 
   return _sumfields_civix_civicrm_enable();


### PR DESCRIPTION
Your code editor may not like this, but this patch fixes the correct way to use ts() in extensions.

* do not split strings on multiple lines
* specify 'domain' => 'net.ourpowerbase.sumfields' in ts() calls.

Mathieu