### PR TITLE
Indicate CiviCRM 4.7 compatibility

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -8,13 +8,14 @@
     <author>Jamie McClelland/Progressive Technology Project</author>
     <email>jamie@progressivetech.org</email>
   </maintainer>
-  <releaseDate>2014-11-18</releaseDate>
-  <version>2.0.5</version>
+  <releaseDate>2016-07-26</releaseDate>
+  <version>2.0.6</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.4</ver>
     <ver>4.5</ver>
     <ver>4.6</ver>
+    <ver>4.7</ver>
   </compatibility>
   <comments>This extension adds custom data fields and triggers to your database. Disabling this extension will cause the custom data fields to be deleted and triggers removed.</comments>
   <civix>


### PR DESCRIPTION
… exist on the same server.

According to the (semi-secret) stats server - 59 sites are currently running Summary Fields on Civi 4.7.  I'm running it myself without an issue.  Though I realize some people running it on 4.7 might get bitten by https://issues.civicrm.org/jira/browse/CRM-18115, but that's not your problem!