### PR TITLE
Fix civicrm navigation menu

### DIFF
--- a/sumfields.php
+++ b/sumfields.php
@@ -24,7 +24,7 @@ function sumfields_civicrm_xmlMenu(&$files) {
  * @param $params array
  */
 function sumfields_civicrm_navigationMenu(&$menu) {
-  _myext_civix_insert_navigation_menu($menu, NULL, array(
+  _sumfields_civix_insert_navigation_menu($menu, NULL, array(
     'label' => ts('Summary Fields', array('net.ourpowerbase.sumfields')),
     'name' => 'Summary Fields',
     'url' => 'civicrm/admin/setting/sumfields',


### PR DESCRIPTION
Enabling this extension blow away the civi menu bar due to this typo.