### PR TITLE
Add Fiscal Year text and a help section to set its value

### DIFF
--- a/custom.php
+++ b/custom.php
@@ -63,7 +63,7 @@ $custom = array(
       'optgroup' => 'fundraising',
     ),
     'contribution_total_this_year' => array(
-      'label' => ts('Total Contributions this Year', array('domain' => 'net.ourpowerbase.sumfields')),
+      'label' => ts('Total Contributions this Fiscal Year', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Money',
       'html_type' => 'Text',
       'weight' => '15',
@@ -89,7 +89,7 @@ $custom = array(
       'optgroup' => 'fundraising',
     ),
     'contribution_total_deductible_this_year' => array(
-      'label' => ts('Total Deductible Contributions this Year', array('domain' => 'net.ourpowerbase.sumfields')),
+      'label' => ts('Total Deductible Contributions this Fiscal Year', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Money',
       'html_type' => 'Text',
       'weight' => '15',
@@ -104,7 +104,7 @@ $custom = array(
       'optgroup' => 'fundraising',
     ),
     'contribution_total_last_year' => array(
-      'label' => ts('Total Contributions last Year', array('domain' => 'net.ourpowerbase.sumfields')),
+      'label' => ts('Total Contributions last Fiscal Year', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Money',
       'html_type' => 'Text',
       'weight' => '20',
@@ -117,7 +117,7 @@ $custom = array(
       'optgroup' => 'fundraising',
     ),
     'contribution_total_deductible_last_year' => array(
-      'label' => ts('Total Deductible Contributions last Year', array('domain' => 'net.ourpowerbase.sumfields')),
+      'label' => ts('Total Deductible Contributions last Fiscal Year', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Money',
       'html_type' => 'Text',
       'weight' => '15',
@@ -132,7 +132,7 @@ $custom = array(
       'optgroup' => 'fundraising',
     ),
     'contribution_total_year_before_last' => array(
-      'label' => ts('Total Contributions Year Before Last', array('domain' => 'net.ourpowerbase.sumfields')),
+      'label' => ts('Total Contributions Fiscal Year Before Last', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Money',
       'html_type' => 'Text',
       'weight' => '20',
@@ -145,7 +145,7 @@ $custom = array(
       'optgroup' => 'fundraising',
     ),
     'contribution_total_deductible_year_before_last_year' => array(
-      'label' => ts('Total Deductible Contributions Year Before Last', array('domain' => 'net.ourpowerbase.sumfields')),
+      'label' => ts('Total Deductible Contributions Fiscal Year Before Last', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Money',
       'html_type' => 'Text',
       'weight' => '15',
@@ -248,7 +248,7 @@ $custom = array(
       'optgroup' => 'soft',
     ),
     'soft_total_this_year' => array(
-      'label' => ts('Total Soft Credits this Year', array('domain' => 'net.ourpowerbase.sumfields')),
+      'label' => ts('Total Soft Credits this Fiscal Year', array('domain' => 'net.ourpowerbase.sumfields')),
       'data_type' => 'Money',
       'html_type' => 'Text',
       'weight' => '15',

--- a/templates/CRM/Sumfields/Form/SumFields.tpl
+++ b/templates/CRM/Sumfields/Form/SumFields.tpl
@@ -30,6 +30,9 @@
     <legend>{$title}</legend>
     <table class="form-layout-compressed">
       {foreach from=$fields key="name" item="description"}
+        {if $name == 'active_fundraising_fields'}
+          <tr><div class="help">{ts}Fiscal Year can be set at <a href="/civicrm-master/civicrm/admin/setting/date?action=reset=1">Administer &gt; Localization &gt; Date Formats</a>{/ts}</div></tr>
+        {/if}
         <tr class="crm-sumfields-form-block-sumfields_{$name}">
           <td class="label">{$form.$name.label}</td>
           <td>


### PR DESCRIPTION
Fix for https://github.com/progressivetech/net.ourpowerbase.sumfields/issues/34#issuecomment-374626251. Help div added on `civicrm/admin/setting/sumfields` which looks like -

![image](https://user-images.githubusercontent.com/5929648/37693356-21c500cc-2ce5-11e8-8ce1-d44561d00efe.png)
