### PR TITLE
#49 fix miscalculation of totals 

### DIFF
--- a/custom.php
+++ b/custom.php
@@ -82,7 +82,7 @@ $custom = array(
       'html_type' => 'Text',
       'weight' => '10',
       'text_length' => '32',
-      'trigger_sql' => '(SELECT IF(SUM(total_amount) IS NULL, 0, SUM(total_amount))
+      'trigger_sql' => '(SELECT IF(SUM(line_total) IS NULL, 0, SUM(line_total))
       FROM civicrm_contribution t1 JOIN 
       civicrm_line_item t2 ON t1.id = t2.contribution_id
       WHERE t1.contact_id = (SELECT contact_id FROM civicrm_contribution cc WHERE cc.id = NEW.contribution_id) AND
@@ -97,7 +97,7 @@ $custom = array(
       'html_type' => 'Text',
       'weight' => '15',
       'text_length' => '32',
-      'trigger_sql' => '(SELECT COALESCE(SUM(total_amount),0)
+      'trigger_sql' => '(SELECT COALESCE(SUM(line_total),0)
       FROM civicrm_contribution t1 
       JOIN civicrm_line_item t2 ON t1.id = t2.contribution_id
       WHERE CAST(receive_date AS DATE) BETWEEN "%current_fiscal_year_begin"
@@ -112,7 +112,7 @@ $custom = array(
       'html_type' => 'Text',
       'weight' => '15',
       'text_length' => '32',
-      'trigger_sql' => '(SELECT COALESCE(SUM(total_amount),0)
+      'trigger_sql' => '(SELECT COALESCE(SUM(line_total),0)
       FROM civicrm_contribution t1 
       JOIN civicrm_line_item t2 ON t1.id = t2.contribution_id
       WHERE CAST(receive_date AS DATE) BETWEEN DATE_SUB(NOW(), INTERVAL 12 MONTH) AND NOW()
@@ -127,7 +127,8 @@ $custom = array(
       'html_type' => 'Text',
       'weight' => '15',
       'text_length' => '32',
-      'trigger_sql' => '(SELECT COALESCE(SUM(line_total),0) - COALESCE(SUM(qty * COALESCE(t3.non_deductible_amount, 0)), 0)
+      // @todo probably should be line total but double check
+      'trigger_sql' => '(SELECT COALESCE(SUM(total_amount),0) - COALESCE(SUM(qty * COALESCE(t3.non_deductible_amount, 0)), 0)
       FROM civicrm_contribution t1 JOIN civicrm_financial_type t2 ON
       t1.financial_type_id = t2.id AND is_deductible = 1 
       JOIN civicrm_line_item t3 ON t1.id = t3.contribution_id
@@ -143,7 +144,7 @@ $custom = array(
       'html_type' => 'Text',
       'weight' => '20',
       'text_length' => '32',
-      'trigger_sql' => '(SELECT COALESCE(SUM(total_amount),0)
+      'trigger_sql' => '(SELECT COALESCE(SUM(line_total),0)
       FROM civicrm_contribution t1 
       JOIN civicrm_line_item t2 ON t1.id = t2.contribution_id
       WHERE CAST(receive_date AS DATE) BETWEEN "%last_fiscal_year_begin"
@@ -175,7 +176,7 @@ $custom = array(
       'html_type' => 'Text',
       'weight' => '20',
       'text_length' => '32',
-      'trigger_sql' => '(SELECT COALESCE(SUM(total_amount),0)
+      'trigger_sql' => '(SELECT COALESCE(SUM(line_total),0)
       FROM civicrm_contribution t1 
       JOIN civicrm_line_item t2 ON t1.id = t2.contribution_id
       WHERE CAST(receive_date AS DATE) BETWEEN "%year_before_last_fiscal_year_begin"
@@ -275,6 +276,7 @@ $custom = array(
       'html_type' => 'Text',
       'weight' => '50',
       'text_length' => '32',
+      // @todo this will be miscalculating
       'trigger_sql' => '(SELECT COALESCE(SUM(total_amount),0) / (SELECT NULLIF(COUNT(DISTINCT SUBSTR(receive_date, 1, 4)), 0)
       FROM civicrm_contribution t0 
       JOIN civicrm_line_item t1 ON t0.id = t1.contribution_id

--- a/sumfields.php
+++ b/sumfields.php
@@ -414,7 +414,6 @@ function sumfields_civicrm_triggerInfo(&$info, $tableName) {
  * data after changing fields, etc.
  */
 function sumfields_create_temporary_table($trigger_table) {
-  $name = CRM_Core_DAO::createTempTableName();
 
   // These are the actual field names as created in this instance
   $custom_fields = _sumfields_get_custom_field_parameters();
@@ -448,10 +447,9 @@ function sumfields_create_temporary_table($trigger_table) {
       }
     }
   }
-  $sql = "CREATE TEMPORARY TABLE `$name` ( ".
-    implode($create_fields, ',') . ')';
-  CRM_Core_DAO::executeQuery($sql);
-  return $name;
+  return CRM_Utils_SQL_TempTable::build()->createWithColumns(
+    implode($create_fields, ',')
+  )->getName();
 }
 
 /**


### PR DESCRIPTION
Fixes a calculation but introduced in .sumfields/commit/28afbe40d21dcf8d05f1959cb8f826d575df360f#diff-2ed8b3d30faed4caf82736f4278b7cc0R105

whereby we wind up with the contribution total * the number of line items rather than the sum of the line items.

Also fixes the temp table create per https://lab.civicrm.org/dev/core/issues/183

