### PR TITLE
Add option to exclude Summary Fields from advanced logging

### DIFF
--- a/CRM/Sumfields/Form/SumFields.php
+++ b/CRM/Sumfields/Form/SumFields.php
@@ -148,6 +148,7 @@ class CRM_Sumfields_Form_SumFields extends CRM_Core_Form {
           ),
         )
       );
+    $this->addYesNo('exclude_from_logging', 'Exclude Summary Fields from logging?');
   }
 
   function setDefaultValues() {
@@ -168,6 +169,7 @@ class CRM_Sumfields_Form_SumFields extends CRM_Core_Form {
     $defaults['participant_noshow_status_ids'] = sumfields_get_setting('participant_noshow_status_ids', array());
     $defaults['when_to_apply_change'] = sumfields_get_setting('when_to_apply_change','via_cron');
     $defaults['data_update_method'] = sumfields_get_setting('data_update_method','via_triggers');
+    $defaults['exclude_from_logging'] = sumfields_get_setting('exclude_from_logging', 0);
     return $defaults;
   }
 
@@ -203,6 +205,7 @@ class CRM_Sumfields_Form_SumFields extends CRM_Core_Form {
     // Save our form page settings
     sumfields_save_setting('data_update_method', $values['data_update_method']);
     sumfields_save_setting('when_to_apply_change', $values['when_to_apply_change']);
+    sumfields_save_setting('exclude_from_logging', $values['exclude_from_logging']);
 
     if ($values['when_to_apply_change'] == 'on_submit') {
       $returnValues = array();

--- a/settings/sumfields.setting.php
+++ b/settings/sumfields.setting.php
@@ -149,4 +149,16 @@ return array(
     'description' => 'Determines when the calculation should take place.On next cron or on submit',
     'help_text' => '',
 	),
+  'exclude_from_logging' => array(
+    'group_name' => 'Summary Fields',
+    'group' => 'summaryfields',
+    'name' => 'exclude_from_logging',
+    'type' => 'Boolean',
+    'default' => '0',
+    'add' => '5.0',
+    'is_domain' => 0,
+    'is_contact' => 0,
+    'description' => 'When advanced logging is turned on, you can exclude Summary Fields from being logged.',
+    'help_text' => '',
+  ),
 );

--- a/sumfields.php
+++ b/sumfields.php
@@ -1410,3 +1410,20 @@ function sumfields_civicrm_merge($type, &$data, $mainId = NULL, $otherId = NULL,
     }
   }
 }
+
+/**
+ * Implements hook_alterLogTables().
+ *
+ * @param array $logTableSpec
+ */
+function sumfields_civicrm_alterLogTables(&$logTableSpec) {
+  $excludeLogging = sumfields_get_setting('exclude_from_logging', 0);
+  if (!$excludeLogging) {
+    return;
+  }
+  $tableName = _sumfields_get_custom_table_name();
+  if (isset($logTableSpec[$tableName])) {
+    unset($logTableSpec[$tableName]);
+  }
+}
+

--- a/templates/CRM/Sumfields/Form/SumFields.tpl
+++ b/templates/CRM/Sumfields/Form/SumFields.tpl
@@ -54,18 +54,26 @@
   </fieldset>
 {/foreach}
 
-  <div id="performance_settings">
-   <div class="label">{$form.data_update_method.label}</div>
-   <span>{$form.data_update_method.html}</span>
-   <div class="description">{ts}If 'Instantly' is selected, data will be more accurate but you might face some performance issues on large installations. <br/> If 'Whenever the cron job is run' is selected, Summary Fields will rely on each CiviCRM Cron job to process all calculations needed for all contacts.{/ts}</div>   
- </div>
- <hr/>
- <div id="when_to_apply_change">
-   <div class="description">{ts}Applying these settings via this form may cause your web server to time out. Applying changes on next scheduled job is recommended.{/ts}</div>
-   <div class="label">{$form.when_to_apply_change.label}</div>
-   <span>{$form.when_to_apply_change.html}</span>
- </div>
-
+  <fieldset>
+  <legend>Performance Settings</legend>
+    <table class="form-layout-compressed">
+      <tr id="performance_settings">
+        <td class="label">{$form.data_update_method.label}</td>
+        <td>{$form.data_update_method.html}
+        <div class="description">{ts}If 'Instantly' is selected, data will be more accurate but you might face some performance issues on large installations. <br/> If 'Whenever the cron job is run' is selected, Summary Fields will rely on each CiviCRM Cron job to process all calculations needed for all contacts.{/ts}</div></td>
+      </tr>
+      <tr id="exclude_from_logging">
+        <td class="label">{$form.exclude_from_logging.label}</td>
+        <td>{$form.exclude_from_logging.html}
+        <div class="description">{ts}When advanced logging is turned on, you can exclude Summary Fields from being logged to increase performance and reduce clutter.{/ts}</div></td>
+      </tr>
+      <tr id="when_to_apply_change">
+        <td class="label">{$form.when_to_apply_change.label}</td>
+        <td>{$form.when_to_apply_change.html}
+        <div class="description">{ts}Applying these settings via this form may cause your web server to time out. Applying changes on next scheduled job is recommended.{/ts}</div></td>
+      </tr>
+    </table>
+ </fieldset>
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 
 {literal}


### PR DESCRIPTION
This patch handles the issues #40 raises in a more general fashion.  Per the conversation on that ticket, this adds an option to exclude the Summary Fields table from advanced logging.

My use case is similar to @scoobird except that my client uses triggers, not cron, to update Summary Fields, so we need to exclude Summary Fields from logging altogether.

Some notes:
* I also reformatted the options at the bottom of the template to improve readability.
* `sumfields_gen_data()` drops and rebuilds triggers, which means that this option will be respected whenever `when_to_apply_change` takes effect - nice!
* There seems to be a fair bit of pre-4.7 and pre-5.0 cruft in here.  Jamie, let me know if you intend to support older versions of Civi with newer versions of the extension.  If not, then the next time I touch the extension I'll do some cleanup.