### PR TITLE
Fix Hook Deprecation issue

### DIFF
--- a/sumfields.php
+++ b/sumfields.php
@@ -823,7 +823,7 @@ function sumfields_get_custom_field_definitions() {
     require 'custom.php';
     // Invoke hook_civicrm_sumfields_definitions
     $null = NULL;
-    CRM_Utils_Hook::singleton()->invoke(1, $custom, $null, $null,
+    CRM_Utils_Hook::singleton()->invoke(['custom'], $custom, $null, $null,
       $null, $null, $null,
       'civicrm_sumfields_definitions'
     );


### PR DESCRIPTION
This aims to fix deprecation notice

`hook_civicrm_sumfields_definitions should be updated to pass an array of parameter names to CRM_Utils_Hook::invoke(). Array ( [civi.tag] => deprecated )`