### PR TITLE
Inconsistent temp table field size on money type

### DIFF
--- a/sumfields.php
+++ b/sumfields.php
@@ -439,7 +439,7 @@ function sumfields_create_temporary_table($trigger_table) {
       if($field_definition['trigger_table'] == $trigger_table) {
         $data_type = $field_definition['data_type'];
         if($data_type == 'Money') {
-          $data_type = "DECIMAL(10,2)";
+          $data_type = "DECIMAL(20,2)";
         }
         elseif($data_type == 'Date') {
           $data_type = 'datetime';


### PR DESCRIPTION
After enabling a money type custom field (e.g. Total Lifetime Contributions), the created field in the Database will have `decimal(20,2)` type. However the temporary table, which is used during (re)generating data uses a `decimal(10,2)` type.

This means that if a contact's lifetime contributions gets above 10 decimals - which can happen as our currency (HUF) is not really strong, so it's not an unrealistic amount - data generation will fail as the calculated value can't be inserted into the temp table.

This patch eliminates this inconsistency.