### PR TITLE
E::ts params

### DIFF
--- a/sumfields.php
+++ b/sumfields.php
@@ -1214,13 +1214,13 @@ function sumfields_alter_table() {
         }
       }
       catch (CiviCRM_API3_Exception $e) {
-        $session->setStatus(E::ts("Error deleting custom field '%1': %2"), array(1 => $field, 2 => $e->getMessage()));
+        $session->setStatus(E::ts("Error deleting custom field '%1': %2", array(1 => $field, 2 => $e->getMessage())));
         // This will result in a error, but let's continue anyway to see if we can get the rest of the fields
         // in working order.
         $ret = FALSE;
         continue;
       }
-      // $session->setStatus(E::ts("Deleted custom field '%1'"), array(1 => $field));
+      // $session->setStatus(E::ts("Deleted custom field '%1'", array(1 => $field)));
       unset($custom_field_parameters[$field]);
     }
   }
@@ -1246,11 +1246,11 @@ function sumfields_alter_table() {
         }
       }
       catch (CiviCRM_API3_Exception $e) {
-        $session->setStatus(E::ts("Error adding custom field '%1': %2"), array(1 => $field, 2 => $e->getMessage()));
+        $session->setStatus(E::ts("Error adding custom field '%1': %2", array(1 => $field, 2 => $e->getMessage())));
         $ret = FALSE;
         continue;
       }
-      // $session->setStatus(E::ts("Added custom field '%1'"), array(1 => $field));
+      // $session->setStatus(E::ts("Added custom field '%1'", array(1 => $field)));
       $value = array_pop($result['values']);
       $custom_field_parameters[$field] = array(
         'id' => $value['id'],


### PR DESCRIPTION
I saw some cryptic error messages:

![error](https://user-images.githubusercontent.com/51154903/148402654-0eb353dc-8ebc-4c77-ab01-9762d14efa8a.png)

I've found calls to `E::ts()` where the actual values for the placeholders are not params for the `E::ts()` functions.
I corrected them, now I can see the real error message (that's not coming from this extension).

![Screenshot from 2022-01-06 15-55-20](https://user-images.githubusercontent.com/51154903/148402332-e1fe48f3-811a-4579-b048-3415c2659c57.png)

I've checked, I think there are no other such calls remained.


