### PR TITLE
Fix database locking during cron updates

### DIFF
--- a/sumfields.php
+++ b/sumfields.php
@@ -527,6 +527,8 @@ function sumfields_generate_data_based_on_current_data($session = NULL) {
     return TRUE;
   }
 
+  $query = 'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;';
+  CRM_Core_DAO::executeQuery($query);
   foreach ($temp_sql as $table => $data) {
     // Calculate data and insert into temp table
     $query = "INSERT INTO `{$data['temp_table']}` SELECT contact_id, "
@@ -548,6 +550,8 @@ function sumfields_generate_data_based_on_current_data($session = NULL) {
     $query = rtrim($query, ',');
     CRM_Core_DAO::executeQuery($query);
   }
+  $query = 'COMMIT;';
+  CRM_Core_DAO::executeQuery($query);
 
   return TRUE;
 }


### PR DESCRIPTION
Hey Jamie,

I think we've discussed how I use cron-based Summary Field updates to avoid missed triggers, but that this prevents contributions from being made while calculations are happening.  Since this can take a couple minutes, it breaks online donations during that time.

I've found a solution though - we can set the transaction isolation level to "READ UNCOMMITTED" while the SQL is creating the temp table.  This reliably allows me to both update and create contributions.

Trying to think through edge cases - I suppose if someone registers for a paid event in the period where the SQL is running, then contribution and event totals may be mismatched until the next run.  But that seems like a small price to pay for being able to register at all.