### PR TITLE
restart stuck cron jobs

### DIFF
--- a/sumfields.php
+++ b/sumfields.php
@@ -1302,7 +1302,18 @@ function sumfields_gen_data(&$returnValues) {
         $status_name = 'scheduled';
       }
     }
+    // Sometimes the cron job gets stuck - because of a timeout, MySQL restart, etc.  Let's assume that it never takes
+    // more than 24 hours to calculate, and if that time has elapsed, we should start over.
+    if ($status_name === 'running') {
+      $now = new DateTime();
+      $lastRun = (new DateTime)::createFromFormat('Y-m-d H:i:s', $status_date);
+      $interval = DateInterval::createFromDateString('3 hours');
+      if ($lastRun->add($interval) < $now) {
+        $status_name = 'scheduled';
+      }
+    }
   }
+
   if ($status_name == 'scheduled') {
 
     $new_status = 'running:' . $date;


### PR DESCRIPTION
Sometimes, a cron job gets stuck as "running".  If that happens, future cron jobs won't recalculate.

This patch assumes that we shouldn't ever need more than 24 hours to recalculate summary fields (I imagine that number could safely be a LOT less, but this should do).  If the cron job hasn't run in 24 hours, it is set to "scheduled".

This will also reset "failed" status, which is intentional, but because that hasn't been handled previously, I'm not sure if that was intentional that failed jobs don't re-run.