### PR TITLE
Restart cron jobs after timeout in failed state also

### DIFF
--- a/sumfields.php
+++ b/sumfields.php
@@ -1303,8 +1303,8 @@ function sumfields_gen_data(&$returnValues) {
       }
     }
     // Sometimes the cron job gets stuck - because of a timeout, MySQL restart, etc.  Let's assume that it never takes
-    // more than 24 hours to calculate, and if that time has elapsed, we should start over.
-    if ($status_name === 'running') {
+    // more than 3 hours to calculate, and if that time has elapsed, we should start over.
+    if (in_array($status_name, ['running', 'failed'])) {
       $now = new DateTime();
       $lastRun = (new DateTime)::createFromFormat('Y-m-d H:i:s', $status_date);
       $interval = DateInterval::createFromDateString('3 hours');

--- a/sumfields.php
+++ b/sumfields.php
@@ -1351,7 +1351,7 @@ function sumfields_gen_data(&$returnValues) {
       }
       else {
         $date = date('Y-m-d H:i:s');
-        $new_status = 'fail:' . $date;
+        $new_status = 'failed:' . $date;
         $exception = TRUE;
         \Civi::log()->debug("Failed to run sumfields_generate_data_based_on_current_data when executing sumfields_gen_data.");
       }


### PR DESCRIPTION
After #109 a timeout (3 hours) is added to still running cron jobs. But jobs can be also failed, and they remain in a failed state, until manually changed.
With this PR the timeout is applied to failed jobs also, so on the next iteration (probably the next day) the job will try to generate the data again.