### PR TITLE
fix largest contribution date simplified calculation

### DIFF
--- a/custom.php
+++ b/custom.php
@@ -529,7 +529,7 @@ $custom = array(
       'trigger_sql' => '(SELECT receive_date 
       FROM civicrm_contribution t1 WHERE t1.contact_id = NEW.contact_id AND
       t1.contribution_status_id = 1 AND t1.financial_type_id IN (%financial_type_ids) AND t1.is_test = 0
-      ORDER BY total_amount, receive_date DESC LIMIT 1)',
+      ORDER BY total_amount DESC, receive_date DESC LIMIT 1)',
       'trigger_table' => 'civicrm_contribution',
       'optgroup' => 'fundraising',
     ),


### PR DESCRIPTION
It looks like "Date of Largest Contribution" was [fixed in 2021](https://github.com/progressivetech/net.ourpowerbase.sumfields/commit/b8610566381b404b44482e084a299b1448e097ff) but the "Simplified" variant wasn't.  This applies the same fix there.