### PR TITLE
don't change the database schema on every cron run

### DIFF
--- a/sumfields.php
+++ b/sumfields.php
@@ -447,10 +447,10 @@ function sumfields_generate_data_based_on_current_data($session = NULL) {
   // disableLoggingForThisConnection() checks the config for logging
   CRM_Logging_Schema::disableLoggingForThisConnection();
 
-  // In theory we shouldn't have to truncate the table, but we
+  // In theory we shouldn't have to delete the records, but we
   // are doing it just to be sure it's empty.
-  $sql = "TRUNCATE TABLE `$table_name`";
-  $dao = CRM_Core_DAO::executeQuery($sql);
+  $sql = "DELETE FROM `$table_name`";
+  CRM_Core_DAO::executeQuery($sql);
 
   // Load the field and group definitions because we need the trigger
   // clause that is stored here. These are the generically shipped
@@ -1340,7 +1340,9 @@ function sumfields_gen_data(&$returnValues) {
     }
     if(!$exception) {
       if(sumfields_generate_data_based_on_current_data()) {
-        CRM_Core_DAO::triggerRebuild();
+        if ($new_active_fields) {
+          CRM_Core_DAO::triggerRebuild();
+        }
         $date = date('Y-m-d H:i:s');
         if ($data_update_method == 'via_cron') {
           // If we have big data, then after a successful task, re-set the status to scheduled


### PR DESCRIPTION
I've been experiencing an issue where my database backups intermittently fail with:
```
mysqldump: Error 1412: Table definition has changed, please retry transaction when dumping table `civicrm_value_summary_field_1` at row: 0
```

This confused me because we shouldn't be altering the table unless we change the configuration.  But it turns out that:
* `TRUNCATE TABLE` works by copying the structure of the table and replacing the old table, which counts as a schema change.
* Changing the triggers apparently counts as a schema change as well (I would've thought they're separate but oh well).

So:
* I've replaced `TRUNCATE` with `DELETE`.  The comment says this isn't necessary, and I'm actually debating whether it does harm (the fields are intermittently empty which is confusing to end users). But I'm limiting my scope here.
* We only need to rebuild the triggers after the field definitions have changed.