### PR TITLE
date param cleanup

### DIFF
--- a/sumfields.php
+++ b/sumfields.php
@@ -564,19 +564,8 @@ function sumfields_generate_data_based_on_current_data($session = NULL) {
 function sumfields_alter_custom_field_create_params(&$params) {
   // Use default date/time formats for Date fields.
   if($params['data_type'] == 'Date') {
-    if (version_compare(CRM_Utils_System::version(), '4.7.alpha1','>=' )) {
-      $params['date_format'] = Civi::settings()->get('dateInputFormat');
-      $params['time_format'] = Civi::settings()->get('timeInputFormat');
-    }
-    else {
-      $params['date_format'] = CRM_Core_Config::singleton()->dateInputFormat;
-      $params['time_format'] = CRM_Core_Config::singleton()->timeInputFormat;
-    }
-    if(empty($params['date_format'])) {
-      // If it is not set for some reason, set it to a default value
-      // otherwise it won't display.
-      $params['date_format'] = 'mm/dd/yy';
-    }
+    $params['date_format'] = Civi::settings()->get('dateInputFormat');
+    $params['time_format'] = Civi::settings()->get('timeInputFormat');
   }
 
   // Don't rebuild triggers or this will take forever.


### PR DESCRIPTION
Just a minor code quality cleanup.  We're not supporting version 4.6, and I tried very hard unsuccessfully to get `Civi::settings()` to return an empty date format and couldn't - so I expect that's also 4.6-related.

I also tried replacing the guts of `sumfields_get_setting()` with `Civi::settings()->get()` but ran into some truthiness issues.